### PR TITLE
Prevent using scientific notation when converting integer to string

### DIFF
--- a/Form/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/Form/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -76,7 +76,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         $moneyParser = new DecimalMoneyParser($this->currencies);
 
         try {
-            $money = $moneyParser->parse(strval($value), $this->currencyCode);
+            $money = $moneyParser->parse(sprintf('%.53f', $value), $this->currencyCode);
             return $money;
         } catch (ParserException $e) {
             throw new TransformationFailedException($e->getMessage());

--- a/Tests/Form/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/Tests/Form/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -31,6 +31,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
             ['en_US', 'USD', 2, true,  999999, '9,999.99', null],
             ['en_US', 'USD', 2, true,  999999, '9,999.99', null],
             ['en_US', 'XBT', 8, true,  999999, '0.00999999', new BitcoinCurrencies()],
+            ['en_US', 'XBT', 8, true,  1, '0.00000001', new BitcoinCurrencies()],
         ];
 
         return $data;


### PR DESCRIPTION
1E-10 is converted to "1E-10" instead of "0.0000000001"