### PR TITLE
Fix hidden dependency on symfony/intl

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Intl\Intl;
 use NumberFormatter;
+use ResourceBundle;
 
 /**
  * This class contains the configuration information for the bundle.
@@ -23,7 +24,9 @@ class Configuration implements ConfigurationInterface
 	 */
 	public function  __construct($locale)
 	{
-		$locales = Intl::getLanguageBundle()->getLocales();
+		$locales = class_exists(ResourceBundle::class)
+			? ResourceBundle::getLocales('')
+			: Intl::getLanguageBundle()->getLocales();
 
 		if (false === in_array($locale, $locales)) {
 			throw new InvalidConfigurationException("Locale '$locale' is not valid.");


### PR DESCRIPTION
I was trying to cut out some useless dependencies like `symfony/form`. After doing that this bundle started failing [here](https://github.com/kucharovic/money-bundle/blob/master/DependencyInjection/Configuration.php#L26) because `symfony/intl` is no longer installed.

One option is to add dependency on `symfony/intl` to `composer.json` but I don't like it since I don't really need that package because I have `intl` extension installed. Can we use something like this instead?