### PR TITLE
Twig 3 Compatibility

### DIFF
--- a/DependencyInjection/JKMoneyExtension.php
+++ b/DependencyInjection/JKMoneyExtension.php
@@ -32,7 +32,7 @@ class JKMoneyExtension extends Extension implements PrependExtensionInterface
 			$formType->replaceArgument(0, $config['currency']);
 		}
 
-		if (interface_exists('Twig_ExtensionInterface')) {
+		if (interface_exists('Twig\Extension\ExtensionInterface')) {
 			$twigExtension = $container->getDefinition('JK\MoneyBundle\Twig\MoneyExtension');
 			$twigExtension->replaceArgument(0, $locale);
 		}

--- a/Tests/DependecyInjection/JKMoneyExtensionTest.php
+++ b/Tests/DependecyInjection/JKMoneyExtensionTest.php
@@ -31,7 +31,7 @@ class JKMoneyExtensionTest extends TestCase
 
 	public function testLoadFormConfiguration()
 	{
-		if (false === interface_exists('Twig_ExtensionInterface')) {
+		if (false === interface_exists('Twig\Extension\ExtensionInterface')) {
 			$this->markTestSkipped('Package `twig/twig` is not available.');
 		}
 		$container = new ContainerBuilder();

--- a/Tests/Twig/MoneyExtensionTest.php
+++ b/Tests/Twig/MoneyExtensionTest.php
@@ -7,6 +7,7 @@ use JK\MoneyBundle\Twig\MoneyExtension;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Money\Money;
 use Money\Currency;
+use Twig\TwigFilter;
 use Locale;
 
 class MoneyExtensionTest extends TestCase
@@ -21,7 +22,7 @@ class MoneyExtensionTest extends TestCase
 		$extension = new MoneyExtension('cs_CZ');
 
 		$this->assertEquals(
-			[new \Twig_SimpleFilter('money', [$extension, 'moneyFilter'])],
+			[new TwigFilter('money', [$extension, 'moneyFilter'])],
 			$extension->getFilters()
 		);
 	}

--- a/Twig/MoneyExtension.php
+++ b/Twig/MoneyExtension.php
@@ -2,19 +2,20 @@
 
 namespace JK\MoneyBundle\Twig;
 
-use Twig_Extension, Twig_SimpleFilter;
 use NumberFormatter, Locale;
 use Money\Money;
 use Money\Currencies\ISOCurrencies;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Formatter\DecimalMoneyFormatter;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /**
  * This class contains the configuration information for the bundle.
  *
  * @author Jakub Kucharovic <jakub@kucharovic.cz>
  */
-class MoneyExtension extends Twig_Extension
+class MoneyExtension extends AbstractExtension
 {
 	const FORMAT_CURRENCY = true;
 	const FORMAT_DECIMAL  = false;
@@ -32,7 +33,7 @@ class MoneyExtension extends Twig_Extension
 	public function getFilters()
 	{
 		return [
-			new Twig_SimpleFilter('money', [$this, 'moneyFilter']),
+			new TwigFilter('money', [$this, 'moneyFilter']),
 		];
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "conflict": {
     "symfony/form": "<3.0",
-    "twig/twig": "<1.30"
+    "twig/twig": "<1.34|>=2.0,<2.4"
   },
   "require": {
     "php": "^7.1",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   "require-dev": {
     "phpunit/phpunit": "^7.0",
     "symfony/form": "^3.0 || ^4.0",
-    "twig/twig": "^1.30 || ^2.0"
+    "twig/twig": "^1.30 || ^2.0 || ^3.0"
   },
   "suggest": {
     "twig/twig": "To use Twig filter to display Money object in your templates",


### PR DESCRIPTION
This PR will add support for Twig 3.x.  The key changes are:

- The bundle now conflicts with Twig versions where the namespaced classes do not exist (everything earlier than 1.34 or 2.0 thru 2.3)
- The bundle now uses the namespaced Twig classes
- The bundle now allows Twig 3.x as a dev dependency