### PR TITLE
Support null returns on the form data transformer

### DIFF
--- a/Form/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/Form/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -69,7 +69,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
      *
      * @param string $value Localized money string
      *
-     * @return \Money\Money Money object
+     * @return \Money\Money|null Money object
      *
      * @throws TransformationFailedException If the given value is not a string
      *                                       or if the value can not be transformed.
@@ -78,11 +78,14 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     {
         $value = parent::reverseTransform($value);
 
+        if (null === $value) {
+            return null;
+        }
+
         $moneyParser = new DecimalMoneyParser($this->currencies);
 
         try {
-            $money = $moneyParser->parse(sprintf('%.53f', $value), $this->currency);
-            return $money;
+            return $moneyParser->parse(sprintf('%.53f', $value), $this->currency);
         } catch (ParserException $e) {
             throw new TransformationFailedException($e->getMessage());
         }

--- a/Tests/Form/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/Tests/Form/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -52,6 +52,16 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals($output, $transformer->transform($input));
     }
 
+    public function testDataTransformEmptyInput()
+    {
+        IntlTestHelper::requireFullIntl($this, false);
+
+        Locale::setDefault('en_US');
+        $transformer = new MoneyToLocalizedStringTransformer(new Currency('USD'), 2, true);
+
+        $this->assertEquals('', $transformer->transform(null));
+    }
+
     /**
      * @dataProvider dataProvider
      */
@@ -65,5 +75,15 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         $input = new Money($input, $currency);
 
         $this->assertEquals($input, $transformer->reverseTransform($output));
+    }
+
+    public function testDataReverseTransformEmptyInput()
+    {
+        IntlTestHelper::requireFullIntl($this, false);
+
+        Locale::setDefault('en_US');
+        $transformer = new MoneyToLocalizedStringTransformer(new Currency('USD'), 2, true);
+
+        $this->assertNull($transformer->reverseTransform(''));
     }
 }


### PR DESCRIPTION
Right now, when using the `MoneyType` form with an empty input, the data transformer turns that into a `Money` instance with a value of 0 (which is a fundamentally different representation of a lack of input).  In my app, I ran into an issue with this conversion because I have an optional money input where if it is filled in then it has to have a value of at least 1 cent, but with the normalization as it's occurring now, I essentially have to treat a 0 cent input as no input.